### PR TITLE
Build OpenDDS3.11 as shared libraries without the version number for Android application.

### DIFF
--- a/odds/Dockerfile
+++ b/odds/Dockerfile
@@ -13,6 +13,7 @@ ADD platform_macros.GNU-x86_64 /home/developer
 # ACE 6.3.2 is added to DDS 3.12.
 ADD platform_android.GNU /home/developer
 ADD config-android.h /home/developer
+ADD opendds.patch /home/developer
 
 USER root
 

--- a/odds/acetaodds-build-x86_64.sh
+++ b/odds/acetaodds-build-x86_64.sh
@@ -12,8 +12,8 @@ unpack_files() {
 
 	# Prepare source for this build as well as the one to follow for the arm.
 	#local HTTP_AT=http://download.ociweb.com/TAO-2.2a
-	local HTTP_DDS=http://download.ociweb.com/OpenDDS
-	#local HTTP_DDS=download.ociweb.com/OpenDDS/previous-releases
+	#local HTTP_DDS=http://download.ociweb.com/OpenDDS
+	local HTTP_DDS=download.ociweb.com/OpenDDS/previous-releases
 	# This version from Vanderbilt fixes CPU_SET_T conflicts.
     local HTTP_AT=download.dre.vanderbilt.edu/previous_versions
 
@@ -28,8 +28,13 @@ unpack_files() {
 	tar -xvzf ./$FILE_DDS
 }
 
+apply_patches() {
+	cd $HOME
+	patch -p0 < opendds.patch
+}
+
 set_build_env() {
-	cd ACE_wrappers
+	cd $BUILD_TOP/ACE_wrappers
 
 	./MPC/clone_build_tree.pl x86_64
 	cd build/x86_64
@@ -79,6 +84,7 @@ compile() {
 }
 
 unpack_files
+apply_patches
 set_build_env
 configure_ace
 generate_makefiles

--- a/odds/opendds.patch
+++ b/odds/opendds.patch
@@ -1,0 +1,28 @@
+diff -Naur arm-tools/ACE_wrappers/include/makeinclude/platform_g++_common.GNU arm-tools.new/ACE_wrappers/include/makeinclude/platform_g++_common.GNU
+--- arm-tools/ACE_wrappers/include/makeinclude/platform_g++_common.GNU	2017-04-20 07:52:06.948646618 +0000
++++ arm-tools.new/ACE_wrappers/include/makeinclude/platform_g++_common.GNU	2017-08-08 20:45:12.102127395 +0000
+@@ -110,6 +110,10 @@
+ # If the platform file didn't already set versioned_so, default to 1.
+ versioned_so ?= 1
+ with_ld ?=
++ifeq ($(versioned_so),0)
++  SOFLAGS += -Wl,-h -Wl,$(SONAME)
++endif
++
+ ifneq ($(versioned_so),0)
+   ifeq ($(with_ld),hpux)
+     SOFLAGS += -Wl,+h -Wl,$(SONAME)
+diff -Naur arm-tools/ACE_wrappers/include/makeinclude/rules.lib.GNU arm-tools.new/ACE_wrappers/include/makeinclude/rules.lib.GNU
+--- arm-tools/ACE_wrappers/include/makeinclude/rules.lib.GNU	2017-04-20 07:52:06.948646618 +0000
++++ arm-tools.new/ACE_wrappers/include/makeinclude/rules.lib.GNU	2017-08-08 20:44:43.769454166 +0000
+@@ -11,6 +11,10 @@
+ #       Library versioning
+ #---------------------------------------------------------------------------
+ 
++ifeq ($(versioned_so),0)
++  SONAME = $(SHLIB)
++endif
++
+ ifneq ($(versioned_so),0)
+   # Turn on symbol versioning. The scheme that we follow is to allow
+   # applications dependent on libraries, with same version numbers (major,

--- a/odds/platform_macros.GNU-arm
+++ b/odds/platform_macros.GNU-arm
@@ -5,4 +5,6 @@ ANDROID_ABI ?= arm64-v8a
 debug = 0
 optimize = 0
 inline = 1
+#static_libs_only = 1
+versioned_so = 0
 include $(ACE_ROOT)/include/makeinclude/platform_android.GNU


### PR DESCRIPTION
Android application can only use shared libraries without the version number. Apply patch to OpenDDS3.11 and update the platform file to generate OpenDDS shared libraries without the version number.